### PR TITLE
Fix ApplyOfficialCuration key resolution for multiple curations

### DIFF
--- a/element_array_ephys/spike_sorting/ephys_curation.py
+++ b/element_array_ephys/spike_sorting/ephys_curation.py
@@ -367,12 +367,16 @@ class ApplyOfficialCuration(dj.Imported):
         """
         from element_array_ephys.readers import kilosort
 
-        curated_files = (ManualCuration.File & key).fetch("file")
+        # Resolve full key including curation_id from OfficialCuration
+        # (key only contains Clustering PK; curation_id is a dependent attribute)
+        official_key = (OfficialCuration & key).fetch1()
+
+        curated_files = (ManualCuration.File & official_key).fetch("file")
         curation_output_dir = (
             next(Path(f) for f in curated_files if Path(f).name == "params.py")
         ).parent
 
-        curation_method = (OfficialCuration * ManualCuration & key).fetch1(
+        curation_method = (ManualCuration & official_key).fetch1(
             "curation_method"
         )
 


### PR DESCRIPTION
## Summary
- Resolve full key (including `curation_id`) from `OfficialCuration` before restricting `ManualCuration.File`
- `key` passed to `make()` only contains Clustering PK; `curation_id` is a dependent attribute of `OfficialCuration`
- Without this fix, `ManualCuration.File & key` matches ALL curations for that Clustering key, causing incorrect file resolution when multiple manual curations exist

## Context
Related to [nei_nienborg#111](https://github.com/dj-sciops/nei_nienborg/issues/111)

This bug is latent in the upstream code but only manifests when multiple `ManualCuration` entries exist for the same `Clustering` key (e.g., after re-curating with Phy).

## Test plan
- [x] Verified locally with lemieux session (2023-02-13, insertion_1) having two ManualCuration entries
- [ ] Run `ApplyOfficialCuration.populate()` end-to-end after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)