### PR TITLE
Fix channel_idx in electrode_map for ApplyOfficialCuration

### DIFF
--- a/element_array_ephys/spike_sorting/ephys_curation.py
+++ b/element_array_ephys/spike_sorting/ephys_curation.py
@@ -435,9 +435,10 @@ class ApplyOfficialCuration(dj.Imported):
 
             sorting_analyzer = si.load_sorting_analyzer(folder=si_sorting_analyzer_dir)
             # Create electrode_map keyed by electrode ID
-            electrode_map: dict[int, dict] = {
-                elec["electrode"]: elec for elec in electrode_query.fetch(as_dict=True)
-            }
+            electrode_map: dict[int, dict] = {}
+            for elec in electrode_query.fetch(as_dict=True):
+                elec.pop("channel_idx")
+                electrode_map[elec["electrode"]] = elec
             # Map device_channel_indices to electrode info using probe's contact_ids
             channel2electrode_map: dict[int, dict] = {
                 chn_idx: electrode_map[int(elec_id)]


### PR DESCRIPTION
## Summary
- Pop `channel_idx` from electrode dicts in the SI sorting_analyzer code path, consistent with the fallback path
- Without this, `channel_idx` is unpacked into the `CuratedClustering.Unit` insert which rejects the unknown field

## Context
Follow-up to PR #19 (channel mapping fix). The SI code path introduced in that PR builds `electrode_map` from `electrode_query` but doesn't exclude `channel_idx`, unlike the fallback path which uses `pop("channel_idx")`.

Related to [nei_nienborg#111](https://github.com/dj-sciops/nei_nienborg/issues/111)

## Test plan
- [ ] Run `ApplyOfficialCuration.populate()` end-to-end with lemieux session

🤖 Generated with [Claude Code](https://claude.com/claude-code)