### PR TITLE
Add infer map functionality for microwire brush arrays as a preprocessing method 

### DIFF
--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -5,6 +5,7 @@ import pathlib
 import re
 from decimal import Decimal
 from typing import Any, Dict, List, Tuple
+
 import datajoint as dj
 import numpy as np
 import pandas as pd
@@ -136,7 +137,7 @@ class AcquisitionSoftware(dj.Lookup):
     """
 
     definition = """  # Name of software used for recording of neuropixels probes - SpikeGLX or Open Ephys
-    acq_software: varchar(24)    
+    acq_software: varchar(24)
     """
     contents = zip(["SpikeGLX", "Open Ephys"])
 
@@ -273,11 +274,11 @@ class EphysRecording(dj.Imported):
 
     definition = """
     # Ephys recording from a probe insertion for a given session.
-    -> ProbeInsertion      
+    -> ProbeInsertion
     ---
     -> probe.ElectrodeConfig
     -> AcquisitionSoftware
-    sampling_rate: float # (Hz) 
+    sampling_rate: float # (Hz)
     recording_datetime: datetime # datetime of the recording from this probe
     recording_duration: float # (seconds) duration of the recording from this probe
     """
@@ -316,7 +317,12 @@ class EphysRecording(dj.Imported):
         supported_probe_types = list(probe.ProbeType.fetch("probe_type"))
         supported_acq_software = list(AcquisitionSoftware.fetch("acq_software"))
 
-        return session_dir, inserted_probe_serial_number, supported_probe_types, supported_acq_software
+        return (
+            session_dir,
+            inserted_probe_serial_number,
+            supported_probe_types,
+            supported_acq_software,
+        )
 
     def make_compute(
         self,
@@ -325,7 +331,13 @@ class EphysRecording(dj.Imported):
         inserted_probe_serial_number: str,
         supported_probe_types: List[str],
         supported_acq_software: List[str],
-    ) -> Tuple[Dict[str, Any], List[Dict[str, Any]], Dict[str, Any], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    ) -> Tuple[
+        Dict[str, Any],
+        List[Dict[str, Any]],
+        Dict[str, Any],
+        List[Dict[str, Any]],
+        List[Dict[str, Any]],
+    ]:
         """Populates table with electrophysiology recording information."""
 
         # Search session dir and determine acquisition software
@@ -507,7 +519,13 @@ class EphysRecording(dj.Imported):
                 f"Processing ephys files from acquisition software of type {acq_software} is not yet implemented."
             )
 
-        return econfig_entry, econfig_electrodes, ephys_recording_entry, ephys_file_entries, ephys_channel_entries
+        return (
+            econfig_entry,
+            econfig_electrodes,
+            ephys_recording_entry,
+            ephys_file_entries,
+            ephys_channel_entries,
+        )
 
     def make_insert(
         self,
@@ -562,9 +580,9 @@ class LFP(dj.Imported):
 
         definition = """
         -> master
-        -> probe.ElectrodeConfig.Electrode  
+        -> probe.ElectrodeConfig.Electrode
         ---
-        lfp: longblob               # (uV) recorded lfp at this electrode 
+        lfp: longblob               # (uV) recorded lfp at this electrode
         """
 
     def make(self, key):
@@ -634,7 +652,9 @@ class LFP(dj.Imported):
             import spikeinterface as si
             from spikeinterface import extractors
 
-            si_extractor = si.extractors.neoextractors.blackrock.BlackrockRecordingExtractor
+            si_extractor = (
+                si.extractors.neoextractors.blackrock.BlackrockRecordingExtractor
+            )
 
             nsx2_relpaths = (EphysRecording.EphysFile & key).fetch("file_path")
             nsx2_fullpaths = [
@@ -665,12 +685,15 @@ class LFP(dj.Imported):
             # single insert in loop to mitigate potential memory issue
             for chn_idx in range(si_recording.get_num_channels()):
                 chn_id = si_recording.channel_ids[chn_idx]
-                lfp = si_recording.get_traces(channel_ids=[chn_id], return_scaled=True).flatten()
-                electrode_key = dict(electrodes_df.query(f"channel_idx == {chn_idx}").iloc[0])
-                self.Electrode.insert1({
-                    **key,
-                    **electrode_key,
-                    "lfp": lfp}, ignore_extra_fields=True)
+                lfp = si_recording.get_traces(
+                    channel_ids=[chn_id], return_scaled=True
+                ).flatten()
+                electrode_key = dict(
+                    electrodes_df.query(f"channel_idx == {chn_idx}").iloc[0]
+                )
+                self.Electrode.insert1(
+                    {**key, **electrode_key, "lfp": lfp}, ignore_extra_fields=True
+                )
         else:
             raise NotImplementedError(
                 f"LFP extraction from acquisition software"
@@ -701,6 +724,7 @@ class ClusteringMethod(dj.Lookup):
         ("kilosort2", "kilosort2 clustering method"),
         ("kilosort2.5", "kilosort2.5 clustering method"),
         ("kilosort3", "kilosort3 clustering method"),
+        ("kilosort4", "kilosort4 clustering method"),
     ]
 
 
@@ -720,7 +744,7 @@ class ClusteringParamSet(dj.Lookup):
     # Parameter set to be used in a clustering procedure
     paramset_idx:  smallint
     ---
-    -> ClusteringMethod    
+    -> ClusteringMethod
     paramset_desc: varchar(128)
     param_set_hash: uuid
     unique index (param_set_hash)
@@ -906,7 +930,7 @@ class Clustering(dj.Imported):
     # Clustering Procedure
     -> ClusteringTask
     ---
-    clustering_time: datetime  # time of generation of this set of clustering results 
+    clustering_time: datetime  # time of generation of this set of clustering results
     package_version='': varchar(16)
     """
 
@@ -1022,7 +1046,7 @@ class CuratedClustering(dj.Imported):
 
     definition = """
     # Clustering results of the spike sorting step.
-    -> Clustering    
+    -> Clustering
     """
 
     class Unit(dj.Part):
@@ -1039,7 +1063,7 @@ class CuratedClustering(dj.Imported):
             spike_depths (longblob): Array of depths associated with each spike, relative to each spike.
         """
 
-        definition = """   
+        definition = """
         # Properties of a given unit from a round of clustering (and curation)
         -> master
         unit: int
@@ -1049,7 +1073,7 @@ class CuratedClustering(dj.Imported):
         spike_count: int         # how many spikes in this recording for this unit
         spike_times: longblob    # (s) spike times of this unit, relative to the start of the EphysRecording
         spike_sites : longblob   # array of electrode associated with each spike
-        spike_depths=null : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe    
+        spike_depths=null : longblob  # (um) array of depths associated with each spike, relative to the (0, 0) of the probe
         """
 
     class ManualLabel(dj.Part):
@@ -1058,7 +1082,7 @@ class CuratedClustering(dj.Imported):
         ---
         manual_label: varchar(64)  # manual label for a particular unit/cluster
         """
-        
+
     def make(self, key):
         """Automated population of Unit information."""
         clustering_method, output_dir = (
@@ -1113,8 +1137,10 @@ class CuratedClustering(dj.Imported):
             }
             channel2electrode_map = {
                 chn_idx: electrode_map[int(elec_id)]
-                for chn_idx, elec_id in zip(sorting_analyzer.get_probe().device_channel_indices,
-                                            sorting_analyzer.get_probe().contact_ids)
+                for chn_idx, elec_id in zip(
+                    sorting_analyzer.get_probe().device_channel_indices,
+                    sorting_analyzer.get_probe().contact_ids,
+                )
             }
 
             # Get unit id to quality label mapping
@@ -1290,8 +1316,8 @@ class WaveformSet(dj.Imported):
         # Spike waveforms and their mean across spikes for the given unit
         -> master
         -> CuratedClustering.Unit
-        -> probe.ElectrodeConfig.Electrode  
-        --- 
+        -> probe.ElectrodeConfig.Electrode
+        ---
         waveform_mean: longblob   # (uV) mean waveform across spikes of the given unit
         waveforms=null: longblob  # (uV) (spike x sample) waveforms of a sampling of spikes at the given electrode for the given unit
         """
@@ -1337,8 +1363,10 @@ class WaveformSet(dj.Imported):
             }
             channel2electrode_map = {
                 chn_idx: electrode_map[int(elec_id)]
-                for chn_idx, elec_id in zip(sorting_analyzer.get_probe().device_channel_indices,
-                                            sorting_analyzer.get_probe().contact_ids)
+                for chn_idx, elec_id in zip(
+                    sorting_analyzer.get_probe().device_channel_indices,
+                    sorting_analyzer.get_probe().contact_ids,
+                )
             }
 
             templates = sorting_analyzer.get_extension("templates")
@@ -1485,7 +1513,7 @@ class QualityMetrics(dj.Imported):
 
     definition = """
     # Clusters and waveforms metrics
-    -> CuratedClustering    
+    -> CuratedClustering
     """
 
     class Cluster(dj.Part):
@@ -1510,26 +1538,26 @@ class QualityMetrics(dj.Imported):
             contamination_rate (float): Frequency of spikes in the refractory period.
         """
 
-        definition = """   
+        definition = """
         # Cluster metrics for a particular unit
         -> master
         -> CuratedClustering.Unit
         ---
-        firing_rate=null: float # (Hz) firing rate for a unit 
+        firing_rate=null: float # (Hz) firing rate for a unit
         snr=null: float  # signal-to-noise ratio for a unit
         presence_ratio=null: float  # fraction of time in which spikes are present
         isi_violation=null: float   # rate of ISI violation as a fraction of overall rate
         number_violation=null: int  # total number of ISI violations
         amplitude_cutoff=null: float  # estimate of miss rate based on amplitude histogram
         isolation_distance=null: float  # distance to nearest cluster in Mahalanobis space
-        l_ratio=null: float  # 
+        l_ratio=null: float  #
         d_prime=null: float  # Classification accuracy based on LDA
         nn_hit_rate=null: float  # Fraction of neighbors for target cluster that are also in target cluster
         nn_miss_rate=null: float # Fraction of neighbors outside target cluster that are in target cluster
         silhouette_score=null: float  # Standard metric for cluster overlap
         max_drift=null: float  # Maximum change in spike depth throughout recording
-        cumulative_drift=null: float  # Cumulative change in spike depth throughout recording 
-        contamination_rate=null: float # 
+        cumulative_drift=null: float  # Cumulative change in spike depth throughout recording
+        contamination_rate=null: float #
         """
 
     class Waveform(dj.Part):
@@ -1549,7 +1577,7 @@ class QualityMetrics(dj.Imported):
             velocity_below (float): inverse velocity of waveform propagation from soma toward the bottom of the probe.
         """
 
-        definition = """   
+        definition = """
         # Waveform metrics for a particular unit
         -> master
         -> CuratedClustering.Unit

--- a/element_array_ephys/spike_sorting/infer_map.py
+++ b/element_array_ephys/spike_sorting/infer_map.py
@@ -4,7 +4,7 @@ import numpy as np
 from sklearn.manifold import Isomap
 
 
-def infer_map(signal, CAR_groups, knn_k=5, scale_method="max", scale_params=None):
+def infer_map(signal, knn_k=5, scale_method="max", scale_params=None):
     """Use Isomap algorithm to infer 2D channel map from correlations within signal array
 
     args:

--- a/element_array_ephys/spike_sorting/infer_map.py
+++ b/element_array_ephys/spike_sorting/infer_map.py
@@ -1,6 +1,7 @@
 """Functions to infer a rough channel map from ephys data, used for microwire brush arrays"""
 
 import numpy as np
+from scipy.spatial.distance import pdist
 from sklearn.manifold import Isomap
 
 
@@ -63,17 +64,17 @@ def scale_map(X, scale_method, scale_params):
     See helper functions (scale_by_*) for scale method details
     """
     if scale_method == "radius":
-        return scale_by_radius(X, scale_params["n_chan"], scale_params["r"])
+        return scale_by_radius(X, **scale_params)
     elif scale_method == "max":
-        return scale_by_max(X, scale_params["max_dist"])
+        return scale_by_max(X, **scale_params)
     else:
         raise NotImplementedError(f"{scale_method} is not a valid scale method")
 
 
 def scale_by_radius(X, n_chan, r):
+    """Scale the inferred coordinates (X) so that no more than n_chan channels lie within a circle of radius r (approx.)"""
     from sklearn.neighbors import kneighbors_graph
 
-    """Scale the inferred coordinates (X) so that no more than n_chan channels lie within a circle of radius r (approx.)"""
     G = kneighbors_graph(X, n_chan, mode="distance", include_self=True).toarray()
     # get smallest distance to the n_chan-th nearest neighbor
     min_dist = G.max(axis=1).min()
@@ -84,8 +85,6 @@ def scale_by_radius(X, n_chan, r):
 
 def scale_by_max(X, max_dist):
     """Scale the inferred coordinates (X) so that the maximum distance between any two points is max_dist"""
-    from scipy.spatial.distance import pdist
-
     X = X / pdist(X).max() * max_dist
     return X
 

--- a/element_array_ephys/spike_sorting/infer_map.py
+++ b/element_array_ephys/spike_sorting/infer_map.py
@@ -1,0 +1,103 @@
+"""Functions to infer a rough channel map from ephys data, used for microwire brush arrays"""
+
+import numpy as np
+from sklearn.manifold import Isomap
+
+
+def infer_map(signal, CAR_groups, knn_k=5, scale_method="max", scale_params=None):
+    """Use Isomap algorithm to infer 2D channel map from correlations within signal array
+
+    args:
+        signal (np.ndarray): 2D numpy array of shape (n_samples, n_channels)
+        knn_k (int): number of nearest neighbors for isomap knn graph
+        scale_method (str): fed to scale_map, see that function for details
+        scale_params (dict): fed to scale_map, see that function for details
+
+    returns:
+        X (np.ndarray): channel map coordinates, of shape (n_channels, 2)
+    """
+    C = signal_to_corr(signal)
+    D = corr_to_dist(C)
+    X = dist_to_coords(D, knn_k)
+    X = scale_map(X, scale_method, scale_params)
+    X = rotate_pc1_vertical(X)
+    return X
+
+
+def signal_to_corr(signal):
+    """Generate correlations from signal"""
+    C = np.corrcoef(signal, rowvar=False)
+    return C
+
+
+def corr_to_dist(C):
+    """Convert pairwise channel correlation matrix C to distance matrix D"""
+    D = 1 - C
+    return D
+
+
+def dist_to_coords(D, knn_k):
+    """Use Isomap to infer channel coordinates from locally valid, approximate distances"""
+    isomap = Isomap(
+        n_neighbors=knn_k, n_components=2, metric="precomputed", eigen_solver="dense"
+    )
+    X = isomap.fit_transform(D)
+    return X
+
+
+def scale_map(X, scale_method, scale_params):
+    """Scale inferred channel map (scale all distances by a linear factor)
+
+    args:
+        X (np.ndarray): (N x 2) map of inferred channel coordinates
+        scale_method (str): method for determining linear factor
+        scale_params (dict): free parameters for scale method
+
+    returns:
+        X (np.ndarray): scaled coordinates
+
+    See helper functions (scale_by_*) for scale method details
+    """
+    if scale_method == "radius":
+        return scale_by_radius(X, scale_params["n_chan"], scale_params["r"])
+    elif scale_method == "max":
+        return scale_by_max(X, scale_params["max_dist"])
+    else:
+        raise NotImplementedError(f"{scale_method} is not a valid scale method")
+
+
+def scale_by_radius(X, n_chan, r):
+    from sklearn.neighbors import kneighbors_graph
+
+    """Scale the inferred coordinates (X) so that no more than n_chan channels lie within a circle of radius r (approx.)"""
+    G = kneighbors_graph(X, n_chan, mode="distance", include_self=True).toarray()
+    # get smallest distance to the n_chan-th nearest neighbor
+    min_dist = G.max(axis=1).min()
+    # scale s.t. the smallest distance to the n_chan-th nearest neighbor is r
+    X_out = X / min_dist * r
+    return X_out
+
+
+def scale_by_max(X, max_dist):
+    """Scale the inferred coordinates (X) so that the maximum distance between any two points is max_dist"""
+    from scipy.spatial.distance import pdist
+
+    X = X / pdist(X).max() * max_dist
+    return X
+
+
+def rotate_pc1_vertical(X):
+    """Helper function used to ensure similar/identical channel maps are visibly similar/identical
+
+    Note that rotation does not alter how the channel map is processed by kilosort, which cares only about distances between channels.
+    """
+    from sklearn.decomposition import PCA
+
+    pc1 = PCA(1).fit(X).components_[0]
+    theta = np.arctan(pc1[1] / pc1[0]) - np.pi / 2
+
+    def R(x):
+        return np.array([[np.cos(x), np.sin(x)], [-np.sin(x), np.cos(x)]])
+
+    X_rot = np.matmul(R(theta), X.T).T
+    return X_rot

--- a/element_array_ephys/spike_sorting/infer_map.py
+++ b/element_array_ephys/spike_sorting/infer_map.py
@@ -16,6 +16,10 @@ def infer_map(signal, knn_k=5, scale_method="max", scale_params=None):
     returns:
         X (np.ndarray): channel map coordinates, of shape (n_channels, 2)
     """
+    # default scaling
+    if scale_method == "max" and not scale_params:
+        scale_params = {"max_dist": 350}
+
     C = signal_to_corr(signal)
     D = corr_to_dist(C)
     X = dist_to_coords(D, knn_k)

--- a/element_array_ephys/spike_sorting/si_preprocessing.py
+++ b/element_array_ephys/spike_sorting/si_preprocessing.py
@@ -56,7 +56,7 @@ def MBA_infer_map(recording, **infer_map_kwargs):
     recording = si.preprocessing.bandpass_filter(
         recording=recording, freq_min=300, freq_max=6000
     )
-    if recording.get_num_channels <= 32:
+    if recording.get_num_channels() <= 32:
         recording = si.preprocessing.common_reference(
             recording=recording, operator="median"
         )

--- a/element_array_ephys/spike_sorting/si_preprocessing.py
+++ b/element_array_ephys/spike_sorting/si_preprocessing.py
@@ -1,3 +1,4 @@
+import numpy as np
 import spikeinterface as si
 from spikeinterface import preprocessing
 
@@ -45,4 +46,51 @@ def NienborgLab_preproc(recording):
     recording = si.preprocessing.common_reference(
         recording=recording, operator="median"
     )
+    return recording
+
+
+def MBA_infer_map(recording, **infer_map_kwargs):
+    """Preprocessing pipeline to infer channel map for microwire brush array data"""
+    from element_array_ephys.spike_sorting.infer_map import infer_map
+
+    recording = si.preprocessing.bandpass_filter(
+        recording=recording, freq_min=300, freq_max=6000
+    )
+    if recording.get_num_channels <= 32:
+        recording = si.preprocessing.common_reference(
+            recording=recording, operator="median"
+        )
+    else:
+        # do common average referencing on each group of 32 channels
+        group_ids = np.arange(recording.get_num_channels(), dtype=int) // 32
+        recording.set_property("group", group_ids)
+        split_recording_dict = recording.split_by("group")
+        split_recording_dict = si.preprocessing.common_reference(split_recording_dict)
+        recording = si.aggregate_channels(split_recording_dict)
+
+    fs = recording.get_sampling_frequency()
+    if recording.get_duration() > 120:
+        # extract second minute of recording (arbitrary)
+        start_frame = 60 * fs
+        end_frame = 120 * fs
+    else:
+        # extract first minute or whole recording
+        start_frame = 0
+        end_frame = int(min(60, recording.get_duration()) * fs)
+
+    signal = recording.get_traces(start_frame=start_frame, end_frame=end_frame).astype(
+        np.float32
+    )
+
+    channel_map = infer_map(signal, **infer_map_kwargs)
+
+    # modify electrode positions within SI object
+    # TODO: eventually figure out a better way to do this
+    si_probe = recording.get_probe()
+    assert (
+        channel_map.shape == si_probe.contact_positions.shape
+    ), f"Inferred coordinates dimensions: {channel_map.shape} do not match target dimensions: {si_probe.contact_positions.shape}"
+    si_probe.set_contacts(positions=channel_map)
+    recording.set_probe(si_probe, in_place=True)
+
     return recording

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -5,14 +5,14 @@ If you use this pipeline, please cite SpikeInterface and the relevant sorter(s) 
 """
 
 from datetime import datetime
+from pathlib import Path
 
 import datajoint as dj
-import pandas as pd
 import spikeinterface as si
-from pathlib import Path
-from element_array_ephys import probe, ephys, readers
 from element_interface.utils import find_full_path, memoized_result
-from spikeinterface import exporters, extractors, sorters
+from spikeinterface import exporters, extractors, sorters  # noqa: F401
+
+from element_array_ephys import ephys, probe, readers
 
 from . import si_preprocessing
 
@@ -90,8 +90,18 @@ class PreProcessing(dj.Imported):
         # Get sorter method and create output directory.
         sorter_name = clustering_method.replace(".", "_")
 
+        # Handle alternative preprocessing params structure
+        if "SI_PREPROCESSING_METHOD" in params:
+            preprocessing_method = params.pop("SI_PREPROCESSING_METHOD")
+            params["SI_PREPROCESSING_PARAMS"] = params.get(
+                "SI_PREPROCESSING_PARAMS", {}
+            )
+            params["SI_PREPROCESSING_PARAMS"][
+                "preprocessing_method"
+            ] = preprocessing_method
+
         for required_key in (
-            "SI_PREPROCESSING_METHOD",
+            "SI_PREPROCESSING_PARAMS",
             "SI_SORTING_PARAMS",
             "SI_POSTPROCESSING_PARAMS",
         ):
@@ -128,23 +138,23 @@ class PreProcessing(dj.Imported):
 
         # Create SI recording extractor object
         if acq_software == "SpikeGLX":
-            si_extractor = si.extractors.neoextractors.spikeglx.SpikeGLXRecordingExtractor
+            si_extractor = (
+                si.extractors.neoextractors.spikeglx.SpikeGLXRecordingExtractor
+            )
             spikeglx_meta_filepaths = (
-                ephys.EphysRecording.EphysFile
-                & key
-                & 'file_path LIKE "%.ap.meta"'
+                ephys.EphysRecording.EphysFile & key & 'file_path LIKE "%.ap.meta"'
             ).fetch("file_path")
             ap_bin_filepaths = [
-                find_full_path(ephys.get_ephys_root_data_dir(), Path(f).with_suffix(".bin"))
+                find_full_path(
+                    ephys.get_ephys_root_data_dir(), Path(f).with_suffix(".bin")
+                )
                 for f in spikeglx_meta_filepaths
             ]
 
             si_recs = []
             for ap_bin_filepath in ap_bin_filepaths:
                 data_dir = ap_bin_filepath.parent
-                spikeglx_recording = readers.spikeglx.SpikeGLX(
-                    data_dir
-                )
+                spikeglx_recording = readers.spikeglx.SpikeGLX(data_dir)
                 spikeglx_recording.validate_file("ap")
                 stream_names, stream_ids = si.extractors.get_neo_streams(
                     "spikeglx", folder_path=data_dir
@@ -169,7 +179,9 @@ class PreProcessing(dj.Imported):
                 folder_path=data_dir, stream_name=stream_names[0]
             )
         elif acq_software == "Trellis":
-            si_extractor = si.extractors.neoextractors.blackrock.BlackrockRecordingExtractor
+            si_extractor = (
+                si.extractors.neoextractors.blackrock.BlackrockRecordingExtractor
+            )
 
             nsx5_relpaths = (ephys.EphysRecording.EphysFile & key).fetch("file_path")
             nsx5_fullpaths = [
@@ -190,7 +202,9 @@ class PreProcessing(dj.Imported):
         in_use_chn_ids = si_recording.channel_ids[electrodes_df.channel_idx.values]
         chn2remove = set(si_recording.channel_ids) - set(in_use_chn_ids)
         si_recording = si_recording.remove_channels(list(chn2remove))
-        in_use_chn_ind = [si_recording.channel_ids.tolist().index(chn_id) for chn_id in in_use_chn_ids]
+        in_use_chn_ind = [
+            si_recording.channel_ids.tolist().index(chn_id) for chn_id in in_use_chn_ids
+        ]
         electrodes_df.channel_idx = in_use_chn_ind
         # Create SI probe object
         si_probe = readers.probe_geometry.to_probeinterface(
@@ -200,8 +214,11 @@ class PreProcessing(dj.Imported):
         si_recording.set_probe(probe=si_probe, in_place=True)
 
         # Run preprocessing and save results to output folder
-        si_preproc_func = getattr(si_preprocessing, params["SI_PREPROCESSING_METHOD"])
-        si_recording = si_preproc_func(si_recording)
+        si_preproc_params = params["SI_PREPROCESSING_PARAMS"]
+        si_preproc_func = getattr(
+            si_preprocessing, si_preproc_params.pop("preprocessing_method")
+        )
+        si_recording = si_preproc_func(si_recording, **si_preproc_params)
         si_recording.dump_to_pickle(file_path=recording_file, relative_to=output_dir)
 
         self.insert1(


### PR DESCRIPTION
## Summary

Microwire Brush Arrays have unknown channel geometry: the relative positions of each electrode are variable within ~a 1mm area. Approximate distances can be inferred using signal correlations across channels in combination with manifold inference techniques. These inferred distances can then be used by spike sorting algorithms (i.e. kilosort) to aid in identifying spikes across channels.

## Changes

1. Add functions to infer channel map from ephys signal (spike_sorting/infer_map.py)
2. Add new preprocessing method: MBA_infer_map, which uses functions from infer_map.py (spike_sorting/si_preprocessing.py)
3. Slightly refactor PreProcessing.make to allow feeding extra parameters to preprocessing methods (useful for MBA_infer_map), through field `SI_PREPROCESSING_PARAMS`. This change maintains backwards compatibility with the old field, `SI_PREPROCESSING_METHOD`, and allows space for other preprocessing methods with free parameters in the future. (spike_sorting/si_spike_sorting.py)
4. Add kilosort4 as a clustering method in ephys.ClusteringMethod lookup table (ephys.py)

## Future Work

1. There may be a better way of implementing this process, which stores information in datajoint tables rather than spikeinterface objects which are then saved to disk.