### PR TITLE
Small QoL changes

### DIFF
--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -1105,8 +1105,7 @@ class CuratedClustering(dj.Imported):
         ephys_sync_func = None
         if use_spikeinterface:
             electrode_map = {
-                elec["electrode"]: elec
-                for elec in electrode_query.fetch(as_dict=True)
+                elec["electrode"]: elec for elec in electrode_query.fetch(as_dict=True)
             }
             ephys_sync_func = get_sync_ephys_function(key)
 
@@ -1299,7 +1298,7 @@ class CuratedClustering(dj.Imported):
                         }
                     )
 
-        return units
+        return (units,)
 
     def make_insert(self, key, units):
         """Insert clustering results, batching units in groups of 64."""

--- a/element_array_ephys/spike_sorting/ephys_curation.py
+++ b/element_array_ephys/spike_sorting/ephys_curation.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
-import os
-import datajoint as dj
+import json
+
+# import os
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
-import json
-import shutil
+
+import datajoint as dj
 import numpy as np
 import pandas as pd
-from element_interface.utils import dict_to_uuid, find_full_path
+from element_interface.utils import find_full_path
 
 from element_array_ephys import ephys
 from element_array_ephys.spike_sorting import si_spike_sorting as ephys_sorter
-
 
 logger = dj.logger
 
@@ -115,13 +116,14 @@ class ManualCuration(dj.Manual):
         if curation_method != "Phy":
             raise ValueError(f"Unsupported curation method: {curation_method}")
 
-        init_datetime = datetime.now(timezone.utc)
+        # init_datetime = datetime.now(timezone.utc)
 
         # Download the spike sorting results
         assert ephys.CuratedClustering & key, f"Invalid ephys.Clustering key: {key}"
         if len(ephys.CuratedClustering.Unit & key) == 0:
             logger.warning("This clustering has no units!!!")
 
+        extra_files = []
         if parent_curation_id == -1:
             assert (
                 ephys_sorter.SIExport & key
@@ -130,6 +132,11 @@ class ManualCuration(dj.Manual):
                 ephys_sorter.SIExport.File
                 & key
                 & "file_name LIKE 'phy%' AND file_name NOT LIKE '%recording.dat'"
+            )
+            extra_files += list(
+                (
+                    ephys_sorter.SIClustering.File & key & "file_name LIKE '%KSLabel%'"
+                ).fetch("file")
             )
         else:
             assert cls & {
@@ -159,6 +166,12 @@ class ManualCuration(dj.Manual):
             f = Path(f)
             if f.name.startswith(".") and f.suffix in (".json", ".pickle"):
                 continue
+            new_f = curation_output_dir / f.name
+            if not new_f.exists() or if_exists == "overwrite":
+                shutil.copy2(f, new_f)
+
+        for f in extra_files:
+            f = Path(f)
             new_f = curation_output_dir / f.name
             if not new_f.exists() or if_exists == "overwrite":
                 shutil.copy2(f, new_f)
@@ -376,9 +389,7 @@ class ApplyOfficialCuration(dj.Imported):
             next(Path(f) for f in curated_files if Path(f).name == "params.py")
         ).parent
 
-        curation_method = (ManualCuration & official_key).fetch1(
-            "curation_method"
-        )
+        curation_method = (ManualCuration & official_key).fetch1("curation_method")
 
         if curation_method != "Phy":
             raise ValueError(f"Unsupported curation method: {curation_method}")

--- a/element_array_ephys/spike_sorting/ephys_curation.py
+++ b/element_array_ephys/spike_sorting/ephys_curation.py
@@ -396,6 +396,10 @@ class ApplyOfficialCuration(dj.Imported):
 
         clus_key = (ephys.Clustering & key).fetch1("KEY")
 
+        assert not (
+            ephys.CuratedClustering.ManualLabel & clus_key
+        ), "An official curation has already been applied: follow manual steps in ApplyOfficialCuration.make docstring"
+
         kilosort_dataset = kilosort.Kilosort(curation_output_dir)
 
         orig_si_unit_map = {

--- a/element_array_ephys/spike_sorting/si_spike_sorting.py
+++ b/element_array_ephys/spike_sorting/si_spike_sorting.py
@@ -392,6 +392,7 @@ class PostProcessing(dj.Imported):
                 folder=analyzer_output_dir,
                 sparse=True,
                 overwrite=True,
+                **job_kwargs,
             )
 
             # The order of extension computation is drawn from sorting_analyzer.get_computable_extensions()


### PR DESCRIPTION
Two tiny changes to manual curation:
1. Fetch the automatic kilosort labels from sorter output and include them in the SI export to phy
2. Warn user on attempt to apply a new manual curation on top of an old one without first resetting CuratedClustering

One small change to spike sorting:
3. Add job_kwargs to create_sorting_analyzer, to enable multiprocessing for the estimate_sparsity step