### PR TITLE
Fix CuratedClustering.make_compute return shape (tripartite tuple contract)

### DIFF
--- a/element_array_ephys/ephys.py
+++ b/element_array_ephys/ephys.py
@@ -1151,7 +1151,7 @@ class CuratedClustering(dj.Imported):
                 logger.info(
                     f"No units found in {sorting_file}. Skipping Unit ingestion..."
                 )
-                return None
+                return (None,)
 
             si_sorting_analyzer_dir = output_dir / sorter_name / "sorting_analyzer"
             sorting_analyzer = si.load_sorting_analyzer(folder=si_sorting_analyzer_dir)
@@ -1299,7 +1299,7 @@ class CuratedClustering(dj.Imported):
                         }
                     )
 
-        return units
+        return (units,)
 
     def make_insert(self, key, units):
         """Insert clustering results, batching units in groups of 64."""


### PR DESCRIPTION
## Summary
- PR #27's `CuratedClustering.make_compute` returned a bare `units` list. DataJoint 0.14.x's `AutoPopulate.make` does `self.make_insert(key, *computed_result)`, so the list elements were unpacked as positional args, raising `TypeError: CuratedClustering.make_insert() takes 3 positional arguments but 769 were given.` on a session with 768 units.
- Wraps both return paths (success and empty-units) in a 1-tuple so `*computed_result` unpacks to a single `units` arg, matching the contract used by `EphysRecording.make_compute` in the same module.
- Also fixes a latent crash on the empty-units path: `return None` would have raised `TypeError: argument of type 'NoneType' is not iterable` at the `*` unpack. With `(None,)` the existing `if units is None: return` guard inside `make_insert` triggers correctly — `self.insert1(key)` runs and the `Unit.insert` loop is skipped, preserving pre-refactor behavior.

## Root cause (verified)
DataJoint 0.14.x `autopopulate.py` (lines 158–168):

```python
fetched_data = self.make_fetch(key, **kwargs)            # tuple
computed_result = self.make_compute(key, *fetched_data)  # MUST be a tuple
self.make_insert(key, *computed_result)                  # unpacked
```

Confirmed against installed 0.14.7 and 0.14.9 sources. `EphysRecording.make_compute` already follows this contract by returning a 5-tuple; `CuratedClustering` deviated, hence the regression.

## Test plan
- [ ] `pytest tests/test_pipeline.py` against the existing test fixture — `tests/conftest.py` already calls `ephys.CuratedClustering.populate()`, and `tests/test_pipeline.py` asserts unit counts and total `spike_count == 328167`. Pre-fix this would crash before the assertions; post-fix the assertions should pass.
- [ ] Run the customer's failing session end-to-end on Alex's machine — `populate(CuratedClustering)` should now ingest all 768 units.
- [ ] Empty-units path: restrict to a session with `si_sorting_.unit_ids.size == 0` and confirm `populate` completes with a `CuratedClustering` row and zero `Unit` rows (no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)